### PR TITLE
global: record file metadata

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -28,5 +28,6 @@ Authors
 Invenio modules that integrates records and files.
 
 - Jiri Kuncar <jiri.kuncar@cern.ch>
+- Lars Holm Nielsen <lars.holm.nielsen@cern.ch>
 - Leonardo Rossi <leonardo.r@cern.ch>
 - Sami Hiltunen <sami.mikael.hiltunen@cern.ch>

--- a/invenio_records_files/utils.py
+++ b/invenio_records_files/utils.py
@@ -27,6 +27,7 @@
 from __future__ import absolute_import, print_function
 
 from invenio_files_rest.models import ObjectVersion
+from invenio_records.errors import MissingModelError
 
 
 def sorted_files_from_bucket(bucket, keys=None):
@@ -36,3 +37,17 @@ def sorted_files_from_bucket(bucket, keys=None):
     sortby = dict(zip(keys, range(total)))
     values = ObjectVersion.get_by_bucket(bucket).all()
     return sorted(values, key=lambda x: sortby.get(x.key, total))
+
+
+def record_file_factory(pid, record, filename):
+    """Get file from a record."""
+    try:
+        if not (hasattr(record, 'files') and record.files):
+            return None
+    except MissingModelError:
+        return None
+
+    try:
+        return record.files[filename]
+    except KeyError:
+        return None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -36,9 +36,11 @@ from invenio_records_files.models import RecordsBuckets
 
 
 @pytest.mark.parametrize('force,num_of_recordbuckets', [(False, 1), (True, 0)])
-def test_cascade_action_record_delete(app, db, location, record, generic_file,
-                                      force, num_of_recordbuckets):
+def test_cascade_action_record_delete(app, db, location, record_with_bucket,
+                                      generic_file, force,
+                                      num_of_recordbuckets):
     """Test cascade action on record delete, with force false."""
+    record = record_with_bucket
     record_id = record.id
     bucket_id = record.files.bucket.id
 


### PR DESCRIPTION
* Adds support for merging file metadata with buckets and objects.

* Fixes bug in _files management when creating files.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>