### PR TITLE
models: remove backref to record

### DIFF
--- a/invenio_records_files/__init__.py
+++ b/invenio_records_files/__init__.py
@@ -94,7 +94,7 @@ You assign a bucket to a record through
 >>> from invenio_files_rest.models import Bucket
 >>> from invenio_records_files.models import RecordsBuckets
 >>> bucket = Bucket.create()
->>> record.model.records_buckets = RecordsBuckets(bucket=bucket)
+>>> record_buckets = RecordsBuckets.create(record=record.model, bucket=bucket)
 
 Normally the bucket creation and bucket to record assignment is done by an
 external module (e.g. Invenio-Deposit is one example of this).

--- a/invenio_records_files/models.py
+++ b/invenio_records_files/models.py
@@ -53,12 +53,11 @@ class RecordsBuckets(db.Model):
     )
 
     bucket = db.relationship(Bucket)
-    record = db.relationship(
-        RecordMetadata,
-        backref=db.backref(
-            'records_buckets',
-            uselist=False,
-            cascade='all, delete-orphan',
-        ),
-        uselist=False,
-    )
+    record = db.relationship(RecordMetadata)
+
+    @classmethod
+    def create(cls, record, bucket):
+        """Create a new RecordsBuckets and adds it to the session."""
+        rb = cls(record=record, bucket=bucket)
+        db.session.add(rb)
+        return rb

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,7 +114,7 @@ def bucket(location, db):
 @pytest.fixture()
 def record_with_bucket(record, bucket, db):
     """Create a bucket."""
-    record.model.records_buckets = RecordsBuckets(bucket=bucket)
+    RecordsBuckets.create(bucket=bucket, record=record.model)
     db.session.commit()
     return record
 

--- a/tests/test_invenio_records_files.py
+++ b/tests/test_invenio_records_files.py
@@ -44,6 +44,11 @@ def test_version():
     assert __version__
 
 
+def test_jsonschemas_import():
+    """Test jsonschemas import"""
+    from invenio_records_files import jsonschemas
+
+
 def test_missing_location(app, db):
     """Test missing location."""
     assert Record.create({}).files is None
@@ -55,7 +60,7 @@ def test_files_property(app, db, location, bucket):
         Record({}).files
 
     record = Record.create({})
-    record.model.records_buckets = RecordsBuckets(bucket=bucket)
+    RecordsBuckets.create(bucket=bucket, record=record.model)
 
     assert 0 == len(record.files)
     assert 'invalid' not in record.files
@@ -212,5 +217,5 @@ def test_record_files_factory(app, db, location, record_with_bucket):
     assert record_file_factory(None, Record({}), 'invalid') is None
     assert record_file_factory(None, BaseRecord({}), 'invalid') is None
     baserecord = BaseRecord.create({})
-    baserecord.model.records_buckets = RecordsBuckets(bucket=Bucket.create())
+    RecordsBuckets(bucket=Bucket.create(), record=baserecord)
     assert record_file_factory(None, baserecord, 'invalid') is None


### PR DESCRIPTION
* INCOMPATIBLE Removes backref to records to prevent double increments of the
  revision_id.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>