### PR TITLE
links: new bucket API link factory

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -30,4 +30,5 @@ Invenio modules that integrates records and files.
 - Jiri Kuncar <jiri.kuncar@cern.ch>
 - Lars Holm Nielsen <lars.holm.nielsen@cern.ch>
 - Leonardo Rossi <leonardo.r@cern.ch>
+- Nikos Filippakis <nikolaos.filippakis@cern.ch>
 - Sami Hiltunen <sami.mikael.hiltunen@cern.ch>

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -42,3 +42,9 @@ Models
 .. automodule:: invenio_records_files.models
    :members:
    :undoc-members:
+
+Links
+-----
+.. automodule:: invenio_records_files.links
+   :members:
+   :undoc-members:

--- a/invenio_records_files/links.py
+++ b/invenio_records_files/links.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Link for file bucket creation."""
+
+from flask import url_for
+
+from .api import Record
+
+
+def default_bucket_link_factory(pid):
+    """Factory for record bucket generation."""
+    try:
+        record = Record.get_record(pid.get_assigned_object())
+        bucket = record.files.bucket
+
+        return url_for('invenio_files_rest.bucket_api',
+                       bucket_id=bucket.id, _external=True)
+    except AttributeError:
+        return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,7 @@ from invenio_db import db as db_
 from invenio_db import InvenioDB
 from invenio_files_rest import InvenioFilesREST
 from invenio_files_rest.models import Bucket, Location
+from invenio_files_rest.views import blueprint as files_rest_blueprint
 from invenio_records import InvenioRecords
 from six import BytesIO
 from sqlalchemy_utils.functions import create_database, database_exists
@@ -57,6 +58,7 @@ def app(request):
         SQLALCHEMY_TRACK_MODIFICATIONS=True,
         TESTING=True,
     )
+    app_.register_blueprint(files_rest_blueprint)
     FlaskCLI(app_)
     InvenioDB(app_)
     InvenioRecords(app_)


### PR DESCRIPTION
* Adds a link factory that generates the link to the bucket of the given
  record.

Signed-off-by: Nikos Filippakis <nikolaos.filippakis@cern.ch>