### PR TITLE
api: lazy initialization of _files field

### DIFF
--- a/invenio_records_files/api.py
+++ b/invenio_records_files/api.py
@@ -105,9 +105,8 @@ class FilesIterator(object):
         self.model = record.model
         self.file_cls = file_cls or FileObject
         self.bucket = bucket
-        self.record.setdefault('_files', [])
         self.filesmap = OrderedDict([
-            (f['key'], f) for f in self.record['_files']
+            (f['key'], f) for f in self.record.get('_files', [])
         ])
 
     @property
@@ -147,7 +146,11 @@ class FilesIterator(object):
 
     def flush(self):
         """Flush changes to record."""
-        self.record['_files'] = self.dumps()
+        files = self.dumps()
+        # Do not create `_files` when there has not been `_files` field before
+        # and the record still has no files attached.
+        if files or '_files' in self.record:
+            self.record['_files'] = files
 
     @_writable
     def __setitem__(self, key, stream):

--- a/tests/test_invenio_records_files.py
+++ b/tests/test_invenio_records_files.py
@@ -64,6 +64,8 @@ def test_files_property(app, db, location, bucket):
 
     assert 0 == len(record.files)
     assert 'invalid' not in record.files
+    # make sure that _files key is not added after accessing record.files
+    assert '_files' not in record
 
     with pytest.raises(KeyError):
         record.files['invalid']


### PR DESCRIPTION
* Makes record updates happen only during files attribute modification.
  (closes inveniosoftware/invenio-deposit#107)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>