### PR TITLE
api: files setter from dict

### DIFF
--- a/invenio_records_files/api.py
+++ b/invenio_records_files/api.py
@@ -297,6 +297,15 @@ class FilesMixin(object):
 
         return self.files_iter_cls(self, bucket=bucket, file_cls=self.file_cls)
 
+    @files.setter
+    def files(self, data):
+        """Set files from data."""
+        current_files = self.files
+        if current_files:
+            raise RuntimeError('Can not update existing files.')
+        for key in data:
+            current_files[key] = data[key]
+
 
 class Record(_Record, FilesMixin):
     """Define API for files manipulation using ``FilesMixin``."""

--- a/tests/test_invenio_records_files.py
+++ b/tests/test_invenio_records_files.py
@@ -198,6 +198,20 @@ def test_filesmixin(app, db, location, record):
     assert record.files is None
 
 
+def test_filesdescriptor(app, db, location, bucket,
+                         record_with_bucket):
+    """Test direct modification files property."""
+    record = record_with_bucket
+
+    record.files = {'hello.txt': BytesIO(b'Hello world!')}
+
+    assert len(record.files) == 1
+    assert len(record['_files']) == 1
+
+    with pytest.raises(RuntimeError):
+        record.files = {'world.txt': BytesIO(b'Hello world!')}
+
+
 def test_bucket_modification(app, db, location, bucket,
                              record_with_bucket):
     """Test direct modification of bucket."""


### PR DESCRIPTION
- Adds method for creating files from a dict if any files have not been
  previously attached to the record.  (closes #21)

Signed-off-by: Jiri Kuncar jiri.kuncar@cern.ch
