### PR TITLE
tests: addition of mock dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ tests_require = [
     'check-manifest>=0.25',
     'coverage>=4.0',
     'isort>=4.2.2',
+    'mock>=1.3.0',
     'pydocstyle>=1.0.0',
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',


### PR DESCRIPTION
* Adds forgotten `mock` dependency for tests.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>