### PR TITLE
release: v1.0.0a10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,17 +58,9 @@ env:
 python:
   - "2.7"
   - "3.5"
-  - "pypy"
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - python: pypy
-
-matrix:
-  fast_finish: true
-  allow_failures:
-    - python: pypy
 
 before_install:
   - "travis_retry pip install --upgrade pip setuptools py"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,6 @@
 Changes
 =======
 
-Version 1.0.0a9 (released 2017-05-16)
+Version 1.0.0a10 (released 2017-11-30)
 
 - Initial public release.

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
-================================
- Invenio-Records-Files v1.0.0a9
-================================
+=================================
+ Invenio-Records-Files v1.0.0a10
+=================================
 
-Invenio-Records-Files v1.0.0a9 was released on May 16, 2017.
+Invenio-Records-Files v1.0.0a10 was released on November 30, 2017.
 
 About
 -----
@@ -19,7 +19,7 @@ What's new
 Installation
 ------------
 
-   $ pip install invenio-records-files==1.0.0a9
+   $ pip install invenio-records-files==1.0.0a10
 
 Documentation
 -------------

--- a/invenio_records_files/version.py
+++ b/invenio_records_files/version.py
@@ -30,4 +30,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "1.0.0a10.dev20170516"
+__version__ = "1.0.0a10"

--- a/setup.py
+++ b/setup.py
@@ -130,7 +130,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
         'Development Status :: 1 - Planning',
     ],
 )


### PR DESCRIPTION
As I was saying in https://github.com/inveniosoftware/invenio-records-files/pull/46, we saw that issue in a production system, so it would be cool to have a release to fix it. I also added a commit to remove the PyPy builds, following a discussion we had a while ago.