### PR TITLE
views: allow url_for usage

### DIFF
--- a/invenio_records_files/views.py
+++ b/invenio_records_files/views.py
@@ -86,7 +86,10 @@ def create_blueprint_from_app(app):
         original values of the request to be unchanged so that it can be
         reproduced.
         """
-        # Value here has been saved in above method (resolve_pid_to_bucket_id)
-        values['pid_value'] = g.pid
+        # NOTE: In some cases the preprocessor is not executed, i.e. url_for,
+        # and g does not contain pid
+        if hasattr(g, 'pid'):
+            # Value here saved in above method (resolve_pid_to_bucket_id)
+            values['pid_value'] = g.pid
 
     return records_files_blueprint

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -13,6 +13,7 @@ from __future__ import absolute_import, print_function
 
 import json
 
+from flask import url_for
 from six import BytesIO
 
 
@@ -62,3 +63,16 @@ def test_record_no_files(app, db, client, location, minted_record_no_bucket):
         data=b'test example'
     )
     assert res.status_code == 404
+
+
+def test_url_for(app):
+    """Test Flask ``url_for`` correct functioning."""
+    with app.test_request_context():
+        url = url_for('invenio_records_files.bucket_api', pid_value=123)
+    assert url == '/records/123/files'
+
+    with app.test_request_context():
+        url = url_for(
+            'invenio_records_files.object_api', pid_value=123, key='test.txt'
+        )
+    assert url == '/records/123/files/test.txt'


### PR DESCRIPTION
* When using `url_for` the url preprocessor is not call as there is no
  request, thus `pid` was not added to `g` or `pid_value` removed from
  `values`.