### PR TITLE
fix: bad downstream dependency in alembic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,11 @@
 Changes
 =======
 
+Version v3.0.0 (released 2026-05-29)
+
+- chore(setup): bump dependencies
+- fix: bad downstream dependency in alembic
+
 Version v2.0.0 (released 2026-01-30)
 
 - chore(context): apply marshmallow context change

--- a/invenio_records_files/__init__.py
+++ b/invenio_records_files/__init__.py
@@ -249,6 +249,6 @@ from __future__ import absolute_import, print_function
 
 from invenio_records_files.ext import InvenioRecordsFiles
 
-__version__ = "2.0.0"
+__version__ = "3.0.0"
 
 __all__ = ("__version__", "InvenioRecordsFiles")

--- a/invenio_records_files/alembic/2da9a03b0833_create_records_files_branch.py
+++ b/invenio_records_files/alembic/2da9a03b0833_create_records_files_branch.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2016-2019 CERN.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -13,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "2da9a03b0833"
-down_revision = "dbdbc1b19cf2"
+down_revision = None
 branch_labels = ("invenio_records_files",)
 depends_on = "dbdbc1b19cf2"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,14 +28,14 @@ python_requires = >=3.7
 zip_safe = False
 install_requires =
     invenio-base>=1.2.2,<3.0.0
-    invenio-files-rest>=4.0.0,<5.0.0
-    invenio-records>=4.0.0,<5.0.0
-    invenio-records-rest>=4.0.0,<5.0.0
+    invenio-files-rest>=5.0.0,<6.0.0
+    invenio-records>=5.0.0,<6.0.0
+    invenio-records-rest>=5.0.0,<6.0.0
 
 [options.extras_require]
 tests =
     pytest-black>=0.6.0
-    invenio-indexer>=4.0.0,<5.0.0
+    invenio-indexer>=5.0.0,<6.0.0
     mock>=1.3.0
     pytest-invenio>=4.0.0,<5.0.0
     Sphinx>=3

--- a/tests/test_alembic.py
+++ b/tests/test_alembic.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015-2020 CERN.
+# Copyright (C) 2026 CESNET z.s.p.o.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+
+"""Alembic upgrade tests."""
+
+import pytest
+
+
+def test_alembic(app, db):
+    """Test alembic recipes."""
+    ext = app.extensions["invenio-db"]
+
+    with app.app_context():
+        if db.engine.name == "sqlite":
+            raise pytest.skip("Upgrades are not supported on SQLite.")
+
+        # ix_uq_partial_files_object_is_head is incorrectly handled for a long time,
+        # so we need to exclude it from the comparison. In RDM-14 migrations, we have
+        # removed it manually.
+        def include_object(object, name, type_, reflected, compare_to):
+            if name == "ix_uq_partial_files_object_is_head":
+                return False
+
+            return True
+
+        app.config["ALEMBIC_CONTEXT"] = {"include_object": include_object}
+        print(app.config["ALEMBIC"])
+
+        assert not ext.alembic.compare_metadata()
+        db.drop_all()
+        ext.alembic.upgrade()
+
+        assert not ext.alembic.compare_metadata()
+        ext.alembic.downgrade(target="2da9a03b0833")
+        ext.alembic.upgrade()
+
+        assert not ext.alembic.compare_metadata()
+        ext.alembic.downgrade(target="2da9a03b0833")


### PR DESCRIPTION
### Description

* The initial migration was generated with invenio-db as a downstream, which creates multiple "default" heads, disrupting alembic revision
* The fix is to use plain depends_on instead of downstream revision
* Tests for upgrade/downgrade added


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
